### PR TITLE
Add meeting schdule doc and append forthcoming meeting to README

### DIFF
--- a/MEETING_SCHEDULE.md
+++ b/MEETING_SCHEDULE.md
@@ -1,0 +1,20 @@
+# Community Meeting Schedule
+
+We set up conference calls monthly to listen to the voices from the Harbor community and also collect related requirements/use cases from our users. There might be a weekly meeting by demand.
+
+**Meeting link**: [https://zoom.us/j/734959521](https://zoom.us/j/734959521)
+
+|      Scheduled Time    |   Speakers   |  Attendees   |     Conf Recording   |                 Main Topic              |  Followup  |
+|------------------------|--------------|--------------|----------------------|-----------------------------------------|-----------|
+| 2018/11/21 | [@mushixun](https://github.com/mushixun)| | | Introduction of feature: Registry operation analysis| |
+| 2018/11/07 | [@yangjunsss](https://github.com/yangjunsss) |||Distribute images via decentralized P2P network||
+| 2018/10/24 | [@steven-zou](https://github.com/steven-zou) |||Harbor+Dragonfly integration demo||
+| 2018/10/10 | [@wang yan](https://github.com/wy65701436) |||Online GC demo||
+| **2018/09/26 06:00-07:00 AM(PDT)/21:00-22:00 (Beijing time)**| [@steven-zou](https://github.com/steven-zou) |||KubeCon event related and goverance model workflow introduction||
+| 2018/09/13 06:00-07:00 AM(PDT)/21:00-22:00 (Beijing time) | [@reasonerjt](https://github.com/reasonerjt) |16|[Recording](https://zoom.us/recording/share/TliR9KB5pD4wtoX9BTazSLcpIqM6HQCH_COMDNHKKD-wIumekTziMw?startTime=1536844010000)|[[Meeting Minutes]](https://github.com/goharbor/community/blob/master/conf-calls/2018-09-13/minutes.md) Harbor V1.7.0 plan items go through||
+| 2018/09/05 06:00-07:00 AM(PDT)/21:00-22:00 (Beijing time) | [@steven-zou](https://github.com/steven-zou),[@cd1989](https://github.com/cd1989), [@stonezdj](https://github.com/stonezdj) | 19 | [Recording](https://zoom.us/recording/share/CcX6hf25ylO9lKD9PRPu2xCgxDdVZOOE099qmYD-WvOwIumekTziMw?startTime=1536152587000)| [[Meeting Minutes]](https://github.com/goharbor/community/blob/master/conf-calls/2018-09-05/minutes.md) Harbor project and community updates; Harbor V1.6 early preview (Part 2): LDAP group and replication label filter; Technical proposal discussion| n/a |
+| 2018/08/22 06:00-07:00 AM(PDT)/21:00-22:00 (Beijing time)| [@steven-zou](https://github.com/steven-zou), [@moooofly](https://github.com/moooofly), [@ninjadq](https://github.com/ninjadq) | 30 | [[Recording]](https://zoom.us/recording/share/xrIpIrM9AJLRCb5LK6-ArNPYiTtimx9_jPQ3tqOywqWwIumekTziMw?startTime=1534942970000)|[[Meeting Minutes]](https://github.com/goharbor/community/blob/master/conf-calls/2018-08-22/minutes.md) **Minutes:** 1. @steven-zou gave latest updates of Harbor 2. go-cli for harbor introduction and discussion by @moooofly 3. @ninjadq from Harbor team demostrate the Helm charts management new feature of Harbor| n/a |
+| 2018/08/08 06:00-07:00 AM(PDT)/21:00-22:00 (Beijing time)| @harbor team| 22 | Not Recorded |Regular meeting: Updates of Harbor donating to CNCF, GitHub repo movement progress, Harbor project updates| n/a |
+|  2018/07/18 06:00-07:00 AM(PDT)| [@nlowe](https://github.com/nlowe)|7 |[Recording](https://VMware.zoom.us/recording/share/tg_0Z1WHJWDSt7v5qE7HSSJuL2eGKurA7lI1LmtupSmwIumekTziMw ) | Discuss the feature 'Keep the latest X tags, clear the old ones'|[Followups](https://github.com/vmware/harbor/wiki/Followup-steps-for-feature-'Keep-the-latest-X-tags,-clear-the-old-ones')|
+| 2018/06/27 06:00-06:30 AM(PDT) |  [@kofj](https://github.com/kofj)   | 12 |[Recording](https://VMware.zoom.us/recording/share/n6Rj3klndmlMjxtkqXReIqExJJ-R5ACX3L4VLJXFhxWwIumekTziMw)|Introduce and demo image build history feature|[Followups](https://github.com/vmware/harbor/wiki/Followup-steps-for-feature-'image-build-history'-developed-by-360-team)| 
+| 2018/06/20 05:30-06:00 AM(PDT) |   [@statemood](https://github.com/statemood)    | 6 |[Recording](https://VMware.zoom.us/recording/share/FHRk_lYCD0zk4vL7LXtD1OpMaOMHFVFk-bUsGgr-adewIumekTziMw )| Review incubating project 'Nowa'        |[Followups](https://github.com/vmware/harbor/wiki/Project-page-for-incubating-project-'Nuwa')|    

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A store for Harbor community related materia.
 
+## Forthcoming Meeting
+
+**Meeting link**: [https://zoom.us/j/734959521](https://zoom.us/j/734959521)
+
+|      Scheduled Time    |   Speakers   |    Main Topic         |
+|------------------------|--------------|-----------------------|
+| **2018/09/26 06:00-07:00 AM(PDT)/21:00-22:00 (Beijing Time)** | [@steven-zou](https://github.com/steven-zou) |KubeCon event related and goverance model workflow introduction|
+
+More details of the conference call, please see [meeting schedule](MEETING_SCHEDULE.md)
+
 ## Structure
 
 * **presentations**: keeps the related slides talking about Harbor


### PR DESCRIPTION
**Add meeting schdule doc and append forthcoming meeting to README**
- add `MEETING_SCHDULE.md` file to record schedule of the community meetings
- append forthcoming meeting link in README

Signed-off-by: Steven Zou <szou@vmware.com>