### PR TITLE
nominate @kofj as harbor maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,3 +23,4 @@ describes governance guidelines and maintainer responsibilities.
 | ---------- | --------- | ----------- |
 | Nathan Lowe | [nlowe](https://github.com/nlowe) | [Hyland Software](https://github.com/HylandSoftware) |
 | De Chen | [cd1989](https://github.com/cd1989) | [Caicloud](https://github.com/caicloud) |
+| Fanjian Kong | [kofj](https://github.com/kofj) | [Qihoo360](https://github.com/Qihoo360) |


### PR DESCRIPTION
[kofj](https://github.com/kofj) is an engineer of Qihu360 company which is a well-known internet security company. He's in charge of operating and maintaining the company internal container registry platform which is built on top of Harbor. He has rich experiences of Harbor and very actively involved in the Harbor community.

He did very important contributions in the last release (v1.7), that is developing the [build history](https://github.com/goharbor/harbor/pull/5371) feature. He's committed to working on the replication enhancement work in next release (V1.8).

I think he's qualified as a maintainer of Harbor community. So I'd like to raise this PR to formally nominate him as Harbor maintainer. Please help to review and vote (approve). Thanks!


Signed-off-by: Steven Zou <szou@vmware.com>