### PR TITLE
update the governance model to reflect the recent changes

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,7 +17,7 @@ maintained under the `goharbor` namespace.
 
 * **[harbor](https://github.com/goharbor/harbor):** Main Harbor codebase.
 * **[harbor-helm](https://github.com/goharbor/harbor-helm):** Helm chart for easy deployment of Harbor
-* **[community](https://github.com/goharbor/community):** Used to store community-related material–e.g., proposals, presentation slides, governance documents, community meeting minutes, etc.
+* **[community](https://github.com/goharbor/community):** Used to store community-related material–e.g., proposals, release plans, workgroup documents, presentation slides, governance documents, community meeting minutes, etc.
 
 ## Community Roles
 
@@ -40,37 +40,51 @@ maintainers.
 ### Maintainers
 
 New maintainers must be nominated by an existing maintainer or core maintainer
-and must be elected by a supermajority of total maintainership. Likewise,
-maintainers can be removed by a supermajority of the total maintainership or
-can resign by notifying the core maintainers.
+and must be elected by a [supermajority](#supermajority) of total maintainership. Likewise,
+maintainers can be removed by a [supermajority](#supermajority) of the total maintainership or can resign by notifying the core maintainers.
 
 ### Core Maintainers
 
 Nomination for core maintainership requires (a) a nomination by an existing
-core maintainer, and (b) election by a supermajority of the core maintainer
-group. Likewise, maintainers can be removed by a supermajority core maintainer
-vote or can resign by notifying the core maintainers.
+core maintainer, and (b) election by a [supermajority](#supermajority) of the core maintainer group. Likewise, maintainers can be removed by a [supermajority](#supermajority) core maintainer vote or can resign by notifying the core maintainers.
 
-### Supermajority
+### Taking Effect
 
-A supermajority is defined as two-thirds of members in the group.
-A supermajority of [Maintainers](#maintainers), [Core
-Maintainers](#core-maintainers), or the union of both is required for certain
-decisions as outlined above.
+Upon adding a new maintainer or core maintainer, the following actions must be performed:
+
+* Update the [MAINTAINERS.md](https://github.com/goharbor/community/blob/master/MAINTAINERS.md) file
+* Add the new maintainer to related mailing groups and social channels if needed
+* Add the new maintainer to the [GitHub](https://github.com/orgs/goharbor/teams) organizations and teams if needed
+* Publish the announcement to the community
 
 ### Decision Making
 
 Ideally, all project decisions are resolved by consensus. If impossible, any
 maintainer may call a vote. Unless otherwise specified in this document, any
-vote will be decided by a supermajority of the total maintainership, with
-a requirement of at least one core maintainer voting.
+vote will be decided by a [simple majority](#simple-majority) of the total maintainership, with a requirement of at least one core maintainer voting.
 
-Votes by maintainers (either core or non-core) belonging to the same company
-will count as one vote; e.g., 4 maintainers employed by company `${x}` will
-only have **one** combined vote. If voting members from a given company do not
-agree, the company's vote is determined by a supermajority of voters from that
-company. If no supermajority is achieved, the company is considered to have
-abstained.
+Votes by maintainers (either core or non-core) belonging to the same organization cannot
+exceed the [Simple majority](#simple-majority) threshold. If the number of maintainers
+(either core or non-core) from the same organization exceeds the simple majority bar, the
+organization should figure out who will be their representatives to give binding votes in
+the voting process. The votes from the non-organization-representative maintainers (either
+core or non-core) will be counted as no-binding votes which will be taken into account when
+the voting is stalemated (50% VS 50%). The binding and non-binding voting rights will be
+marked in the [MAINTAINERS.md](https://github.com/goharbor/community/blob/master/MAINTAINERS.md) file.
+
+Any changes to the [MAINTAINERS.md](https://github.com/goharbor/community/blob/master/MAINTAINERS.md) file will be considered as governance model changes.
+
+### Supermajority
+
+A supermajority is defined as two-thirds of members in the group.
+A supermajority of [Maintainers](#maintainers), [Core Maintainers](#core-maintainers), or 
+the union of both is required for certain decisions as outlined above.
+
+### Simple majority
+
+A simple majority is defined as more than half of members in the group.
+A simple majority of the [Total Maintainership](#total-maintainership) is required for 
+certain decisions as outlined in the document.
 
 ## Proposal Process
 
@@ -89,7 +103,7 @@ recommendations on how to implement. In general, the community member(s)
 interested in implementing the proposal should be either deeply engaged in the
 proposal process or be an author of the proposal.
 
-The proposal should be documented as a separated markdown file pushed to the root of the 
+The proposal should be documented as a separated markdown file pushed to the root of the
 `proposals` folder in the [community](https://github.com/goHarbor/community)
 repository via PR. The name of the file should follow the name pattern `<short
 meaningful words joined by '-'>_proposal.md`, e.g:
@@ -106,6 +120,19 @@ status of the proposal:
 * **Reviewing**: Proposal is under review and discussion.
 * **Accepted**: Proposal is reviewed and accepted (either by consensus or vote).
 * **Rejected**: Proposal is reviewed and rejected (either by consensus or vote).
+
+## Other Projects
+
+The Harbor organization is open to receive new sub-projects under its umbrella. To accept a
+project into the Harbor organization, it must meet the following criteria:
+
+* Must be related to Harbor and its ecosystem, as decided by the core maintainers.
+* Must be licensed under the terms of the Apache License v2.0
+* Must have more than two contributors
+
+The submission process starts as a Pull Request on the [goharbor/community](https://github.com/goharbor/community) 
+repository with the required information mentioned above. Once a project is determined to 
+be accepted by supermajority voting, it's considered a CNCF sub-project under the umbrella of Harbor.
 
 ## Lazy Consensus
 
@@ -132,8 +159,13 @@ repo that includes proposals and governing documents.
 Lazy consensus does _not_ apply to the process of:
 
 * Removing core or non-core maintainers
+* Changing governance model
 
 ## Updating Governance
 
 All substantive changes in Governance require a supermajority [Total
 Maintainership](#total-maintainership) vote.
+
+## Code of Conduct
+
+Harbor follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
Signed-off-by: Steven Zou <szou@vmware.com>

**Background**

Harbor is committed to building an open, inclusive, productive and self-governing open source community. The development of the community should be promoted by all the participants and the Harbor community encourages active participation from any organizations/individuals who're interested in Harbor and willing to doing contributions to promote the community. 

Recently, more and more organizations have expressed willings to participate in the Harbor community and some of them have done significant contributions to Harbor. In the future, there will be more and more maintainers (with a reasonable number) to join the community and work together to maintain the community.

In addition, at present, companies play a large role in sponsoring projects with engineers and contributions in open source projects. The governance model should reflect and reward their contributions. Of course, there should not be a majority formed by individual companies. 

**Motivation**

The decision-making rule defined in the current governance model cannot help to obtain the above expectations. It defines 
>Votes by maintainers (either core or non-core) belonging to the same company will count as one vote; e.g., 4 maintainers employed by company ${x} will only have one combined vote`. 

The rule seems too restrictive and does not equally reflect the contributions from the organizations. Use VMware team as an example, they allocate 8 engineers working on the Harbor projects and did more than 80% contributions to the projects. With the above rule, they have only 1 vote, totally the same with the other organizations which have only 1 engineer. With the current situation, only got 1/4=25% voting weight. If adding two more maintainers, the voting weight will be down to 1/6=16% The voting weight does not match the contributions they did very much. Moreover, with the current governance model, the companies that bring additional engineers are disincentivized.

To reflect and reward the real contributions of the organization to the utmost extent and make sure the rule that there will not be a majority formed by individual companies is broken, the current decision-making rule will be changed to a more reasonable and suitable one.

Besides the primary change to the decision-making rule, to make the model more substantial, COC and other project accepting process sections are appended. Moreover, supplement more requirements to the maintainer/core maintainer nomination processes.

**Goal**

Propose a rule to reward proportional representation below majority control and complete and simplify the overall process.

**Changes**

* **update decision-making section**: downgrade the limitations to the votes from the same org
* update the maintainer nomination requirements  
* update the core maintainer nomination requirements
* primary voting approach for making decisions is changed from supermajority to simple majority to simplify the process
* append simple majority subsections
* append COC section
* append project accepting process section
* misc format changes

**Discussions**

This PR will be discussed at the next harbor community call where community members can raise any questions or concerns.