### PR TITLE
Move several maintainers from core to maintainer group

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,17 +9,17 @@ describes governance guidelines and maintainer responsibilities.
 | --------------- | --------- | ----------- |
 | Daniel Jiang | [reasonerjt](https://github.com/reasonerjt) | [VMware](https://www.github.com/vmware/) |
 | Steven Ren | [renmaosheng](https://github.com/renmaosheng) | [VMware](https://www.github.com/vmware/) |
-| Daojun Zhang | [stonezdj](https://github.com/stonezdj) | [VMware](https://www.github.com/vmware/) |
-| Wenkai Yin | [ywk253100](https://github.com/ywk253100) | [VMware](https://www.github.com/vmware/) |
-| Yan | [wy65701436](https://github.com/wy65701436) | [VMware](https://www.github.com/vmware/) |
-| Qian Deng | [ninjadq](https://github.com/ninjadq) | [VMware](https://www.github.com/vmware/) |
-| Mia Zhou | [zhoumeina](https://github.com/zhoumeina) | [VMware](https://www.github.com/vmware/) |
 | Steven Zou | [steven-zou](https://github.com/steven-zou) | [VMware](https://www.github.com/vmware/) |
 
 ## Maintainers
 
 | Maintainer | GitHub ID | Affiliation |
 | ---------- | --------- | ----------- |
+| Daojun Zhang | [stonezdj](https://github.com/stonezdj) | [VMware](https://www.github.com/vmware/) |
+| Wenkai Yin | [ywk253100](https://github.com/ywk253100) | [VMware](https://www.github.com/vmware/) |
+| Yan | [wy65701436](https://github.com/wy65701436) | [VMware](https://www.github.com/vmware/) |
+| Qian Deng | [ninjadq](https://github.com/ninjadq) | [VMware](https://www.github.com/vmware/) |
+| Mia Zhou | [zhoumeina](https://github.com/zhoumeina) | [VMware](https://www.github.com/vmware/) |
 | Nathan Lowe | [nlowe](https://github.com/nlowe) | [Hyland Software](https://github.com/HylandSoftware) |
 | De Chen | [cd1989](https://github.com/cd1989) | [Caicloud](https://github.com/caicloud) |
 | Mingming Pei | [mmpei](https://github.com/mmpei) | [Netease](https://github.com/netease) |


### PR DESCRIPTION
To achieve a more fair community and maintainership as well as effectively running the community, the following maintainers voluntarily step out of the core group and step into the maintainer group. Big thanks for their actions, really appreciated! Let's keep on working closely to promote our Harbor project and the community!

They are:

| Maintainer | GitHub ID | Affiliation |
| --------------- | --------- | ----------- |
| Daojun Zhang | [stonezdj](https://github.com/stonezdj) | [VMware](https://www.github.com/vmware/) |
| Wenkai Yin | [ywk253100](https://github.com/ywk253100) | [VMware](https://www.github.com/vmware/) |
| Yan | [wy65701436](https://github.com/wy65701436) | [VMware](https://www.github.com/vmware/) |
| Qian Deng | [ninjadq](https://github.com/ninjadq) | [VMware](https://www.github.com/vmware/) |
| Mia Zhou | [zhoumeina](https://github.com/zhoumeina) | [VMware](https://www.github.com/vmware/) |

Signed-off-by: Steven Zou <szou@vmware.com>