### PR TITLE
maintainer updates

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,7 +21,7 @@ describes governance guidelines and maintainer responsibilities.
 | Wenkai Yin | [ywk253100](https://github.com/ywk253100) | [VMware](https://www.github.com/vmware/) |
 | Yan | [wy65701436](https://github.com/wy65701436) | [VMware](https://www.github.com/vmware/) |
 | Qian Deng | [ninjadq](https://github.com/ninjadq) | [VMware](https://www.github.com/vmware/) |
-| Mia Zhou | [zhoumeina](https://github.com/zhoumeina) | [VMware](https://www.github.com/vmware/) |
+| Daniel Pacak | [danielpacak](https://github.com/danielpacak) | [Aqua Security](https://www.github.com/aquasecurity/) |
 | Nathan Lowe | [nlowe](https://github.com/nlowe) | [Hyland Software](https://github.com/HylandSoftware) |
 | De Chen | [cd1989](https://github.com/cd1989) | Independent |
 | Mingming Pei | [mmpei](https://github.com/mmpei) | [Netease](https://github.com/netease) |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,7 @@ describes governance guidelines and maintainer responsibilities.
 | Steven Ren | [renmaosheng](https://github.com/renmaosheng) | [VMware](https://www.github.com/vmware/) |
 | Steven Zou | [steven-zou](https://github.com/steven-zou) | [VMware](https://www.github.com/vmware/) |
 | Michael Michael |[michmike](https://github.com/michmike)| [VMware](https://www.github.com/vmware/) |
+| Henry Zhang| [hainingzhang](https://github.com/hainingzhang)| [VMware](https://www.github.com/vmware/) | 
 
 ## Maintainers
 
@@ -28,7 +29,5 @@ describes governance guidelines and maintainer responsibilities.
 
 ## Emeritus Maintainers
 
-| Core Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Henry Zhang| [hainingzhang](https://github.com/hainingzhang)| [VMware](https://www.github.com/vmware/) |
+N/A
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,6 @@ describes governance guidelines and maintainer responsibilities.
 | Daniel Jiang | [reasonerjt](https://github.com/reasonerjt) | [VMware](https://www.github.com/vmware/) |
 | Steven Ren | [renmaosheng](https://github.com/renmaosheng) | [VMware](https://www.github.com/vmware/) |
 | Steven Zou | [steven-zou](https://github.com/steven-zou) | [VMware](https://www.github.com/vmware/) |
-| Henry Zhang| [hainingzhang](https://github.com/hainingzhang)| [VMware](https://www.github.com/vmware/) |
 | Michael Michael |[michmike](https://github.com/michmike)| [VMware](https://www.github.com/vmware/) |
 
 ## Maintainers
@@ -26,3 +25,10 @@ describes governance guidelines and maintainer responsibilities.
 | De Chen | [cd1989](https://github.com/cd1989) | Independent |
 | Mingming Pei | [mmpei](https://github.com/mmpei) | [Netease](https://github.com/netease) |
 | Fanjian Kong | [kofj](https://github.com/kofj) | [Qihoo360](https://github.com/Qihoo360) |
+
+## Emeritus Maintainers
+
+| Core Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Henry Zhang| [hainingzhang](https://github.com/hainingzhang)| [VMware](https://www.github.com/vmware/) |
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,7 @@ describes governance guidelines and maintainer responsibilities.
 | Steven Ren | [renmaosheng](https://github.com/renmaosheng) | [VMware](https://www.github.com/vmware/) |
 | Steven Zou | [steven-zou](https://github.com/steven-zou) | [VMware](https://www.github.com/vmware/) |
 | Michael Michael |[michmike](https://github.com/michmike)| [VMware](https://www.github.com/vmware/) |
-| Henry Zhang| [hainingzhang](https://github.com/hainingzhang)| [VMware](https://www.github.com/vmware/) | 
+| Henry Zhang | [hainingzhang](https://github.com/hainingzhang)| [VMware](https://www.github.com/vmware/) | 
 
 ## Maintainers
 


### PR DESCRIPTION
Hello @goharbor/all-maintainers,

we would like to propose the addition of a new maintainer in Harbor to replace an existing one.

Daniel Pacak (@danielpacak) from Aqua Security has been instrumental in the architecture and delivery of the Pluggable Scanner work in 1.10. Daniel will have a specific job in the maintainers of Harbor, focusing on the security aspects and related work of Harbor and the pluggable scanner work.

Please vote on the new addition to the maintainers team of Harbor and congratulate Daniel on a great job so far!

In addition,  Mia Zhou (@zhoumeina) is departing our maintainers team. We thank Mia for her hard work and contributions to Harbor. Mia is changing her primary focus to work on other products, but will continue to help the Harbor team from time to time.

Signed-off-by: Michael Michael <michmike@cs.stanford.edu>