### PR TITLE
docs(scanner): doc for registry authorization type property

### DIFF
--- a/proposals/pluggable-image-vulnerability-scanning_proposal.md
+++ b/proposals/pluggable-image-vulnerability-scanning_proposal.md
@@ -75,7 +75,7 @@ configure, at runtime, and on a per-project basis:
 3. Persistence of the scan results in support of audit history
 4. Visualizations of some or all of the scan results for users directly in Harbor
 
-### Alignment and Scope of this Proposal to Long-Term Objectives 
+### Alignment and Scope of this Proposal to Long-Term Objectives
 
 Given that broader long-term objective, this proposal addresses the initial steps required to provide pluggable image
 scanning for vulnerabilities, while providing the framework to build upon towards the longer-term artifact scanning
@@ -339,10 +339,14 @@ Scanner vendors are supposed to implement Scanner Adapters exposing the Scanner 
      ],
      "properties": {
        "harbor.scanner-adapter/scanner-type": "os-package-vulnerability",
-       "harbor.scanner-adapter/vulnerability-database-updated-at": "2019-08-13T08:16:33.345Z"
+       "harbor.scanner-adapter/vulnerability-database-updated-at": "2019-08-13T08:16:33.345Z",
+       "harbor.scanner-adapter/registry-authorization-type": "Basic"
      }
    }
    ```
+
+   Note: "harbor.scanner-adapter/registry-authorization-type" decide the authorization type when submit the scan request in Harbor, currently allowed value is "Basic" and "Bearer". This property is optional, if it is not set 'Basic' will be applied when submitting the scan request.
+
 2. Submit the scan request
    1. Submit an invalid scan request:
        ```
@@ -378,7 +382,7 @@ Scanner vendors are supposed to implement Scanner Adapters exposing the Scanner 
        {
          "registry": {
            "url": "harbor-harbor-registry:5000",
-           "authorization": "Bearer: JWTTOKENGOESHERE"
+           "authorization": "Bearer JWTTOKENGOESHERE"
          },
          "artifact": {
            "repository": "library/mongo",


### PR DESCRIPTION
Add document for `harbor.scanner-adapter/registry-authorization-type` property in metadata of scanner adapter, harbor will use this property to chose the  authorization type send to adapter when submit the scan request.  

Signed-off-by: He Weiwei <hweiwei@vmware.com>