### PR TITLE
Fix minor typo in link to holyhope's GitHub

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,7 +17,7 @@ describes governance guidelines and maintainer responsibilities.
 | Henry Zhang | [hainingzhang](https://github.com/hainingzhang)| [VMware](https://www.github.com/vmware/) | 
 | Steven Zou | [steven-zou](https://github.com/steven-zou) | [VMware](https://www.github.com/vmware/) |
 | Jérémie MONSINJON | [Jérémie MONSINJON](https://github.com/jMonsinjon) | [OVH Cloud](https://www.ovh.com/world/) | 
-| Pierre PÉRONNET | [holyhope](github.com/holyhope) | [OVH Cloud](https://www.ovh.com/world/) |
+| Pierre PÉRONNET | [holyhope](https://github.com/holyhope) | [OVH Cloud](https://www.ovh.com/world/) |
 | Alex Xu | [xaleeks](https://github.com/xaleeks) | [VMware](https://www.github.com/vmware/) |
 | Tianon Gravi| [tianon](https://github.com/tianon) | [InfoSiftr](https://github.com/infosiftr) |
 | Vadim Bauer| [Vad1mo](https://github.com/Vad1mo) | [56K.Cloud](https://container-registry.com) |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,8 +19,8 @@ describes governance guidelines and maintainer responsibilities.
 | Jérémie MONSINJON | [Jérémie MONSINJON](https://github.com/jMonsinjon) | [OVH Cloud](https://www.ovh.com/world/) | 
 | Pierre PÉRONNET | [holyhope](https://github.com/holyhope) | [OVH Cloud](https://www.ovh.com/world/) |
 | Alex Xu | [xaleeks](https://github.com/xaleeks) | [VMware](https://www.github.com/vmware/) |
-| Tianon Gravi| [tianon](https://github.com/tianon) | [InfoSiftr](https://github.com/infosiftr) |
-| Vadim Bauer| [Vad1mo](https://github.com/Vad1mo) | [56K.Cloud](https://container-registry.com) |
+| Tianon Gravi | [tianon](https://github.com/tianon) | [InfoSiftr](https://github.com/infosiftr) |
+| Vadim Bauer | [Vad1mo](https://github.com/Vad1mo) | [56K.Cloud](https://container-registry.com) |
 
 ## SIG Community
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,7 +20,7 @@ describes governance guidelines and maintainer responsibilities.
 | Pierre PÉRONNET | [holyhope](https://github.com/holyhope) | [OVH Cloud](https://www.ovh.com/world/) |
 | Alex Xu | [xaleeks](https://github.com/xaleeks) | [VMware](https://www.github.com/vmware/) |
 | Tianon Gravi | [tianon](https://github.com/tianon) | [InfoSiftr](https://github.com/infosiftr) |
-| Vadim Bauer | [Vad1mo](https://github.com/Vad1mo) | [56K.Cloud](https://container-registry.com) |
+| Vadim Bauer | [Vad1mo](https://github.com/Vad1mo) | [8gears](https://container-registry.com) |
 
 ## SIG Community
 


### PR DESCRIPTION
Looks like this was missed in https://github.com/goharbor/community/pull/127 and causes the link to lead to https://github.com/goharbor/community/blob/master/github.com/holyhope instead of https://github.com/holyhope.