### PR TITLE
Move Daniel P. to Emeritus Maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,6 @@ describes governance guidelines and maintainer responsibilities.
 | --------------- | --------- | ----------- |
 | Daniel Jiang | [reasonerjt](https://github.com/reasonerjt) | [VMware](https://www.github.com/vmware/) |
 | Fanjian Kong | [kofj](https://github.com/kofj) | [Tencent](https://github.com/Tencent) |
-| Daniel Pacak | [danielpacak](https://github.com/danielpacak) | [Aqua Security](https://www.github.com/aquasecurity/) |
 | Mingming Pei | [mmpei](https://github.com/mmpei) | [Netease](https://github.com/netease) |
 | Steven Ren | [renmaosheng](https://github.com/renmaosheng) | [VMware](https://www.github.com/vmware/) |
 | Yan Wang | [wy65701436](https://github.com/wy65701436) | [VMware](https://www.github.com/vmware/) |
@@ -42,13 +41,13 @@ describes governance guidelines and maintainer responsibilities.
 | Harbor Core | Daniel Jiang (reasonerjt) |
 | Replication Working Group | Steven Zou (steven-zou), Wenkai Yin (ywk253100) |
 | Webhooks | MingMing Pei (mmpei), Yan Wang (wy65701436) |
-| Interrogation Service/Pluggable Scanners | Daniel Pacak (danielpacak), Zach Hill (zhill), Steven Zou (steven-zou) |
+| Interrogation Service/Pluggable Scanners | Zach Hill (zhill), Steven Zou (steven-zou) |
 | Setup, Installation, Upgrade Experience | Daojun Zhang (stonezdj) , Qian Deng (ninjadq) |
 | Helm Chart & HA | Wenkai Yin (ywk253100), Daniel Jiang (reasonerjt) |
 | Policy Engine | Yan Wang (wy65701436), Steven Zou (steven-zou) |
 | Scheduling Engine | Steven Zou (steven-zou) |
 | Operator & Day 2 Operations | Jérémie MONSINJON (jMonsinjon), Pierre PÉRONNET (holyhope), Steven Zou (steven-zou) |
-| Security | Daniel Pacak (danielpacak) |
+| Security | TBD |
 | User Interface/Usability/User Experience | Meina Zhou (zhoumeina) |
 | Scale & Performance | Weiwei He (heww), Ziming Zhang (bitsf) |
 | Documentation | Abigail McCarthy (a-mccarthy) |
@@ -58,7 +57,10 @@ describes governance guidelines and maintainer responsibilities.
 | Product Management | Roger Klorese (qnetter) |
 
 ## Emeritus Maintainers
+
 * Michael Michael, [michmike](https://github.com/michmike)
 * Nathan Lowe, [nlowe](https://github.com/nlowe)
 * Alex Xu, [xaleeks](https://github.com/xaleeks)
 * Tianon Gravi, [tianon](https://github.com/tianon)
+* Daniel Pacak, [danielpacak](https://github.com/danielpacak)
+


### PR DESCRIPTION
Collaborating here has been an honor and privilege, and I'm definitely still open to helping out where my knowledge might be useful.

I don't have the bandwidth to do significant contributions anymore, but I'm sure folks from Aqua Security team will help maintaining [Trivy](https://github.com/aquasecurity/trivy) cloud native security scanner and take Harbor Interrogation Service to the next level.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>