### PR TITLE
Add subproject governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -19,10 +19,14 @@ maintained under the `goharbor` namespace.
 * **[harbor-helm](https://github.com/goharbor/harbor-helm):** Helm chart for easy deployment of Harbor
 * **[community](https://github.com/goharbor/community):** Used to store community-related material–e.g., proposals, presentation slides, governance documents, community meeting minutes, etc.
 
+Long-lived repository or component ownership is documented through
+[subproject governance](SUBPROJECT_GOVERNANCE.md).
+
 ## Community Roles
 
 * **Users:** Members that engage with the Harbor community via any medium (Slack, WeChat, GitHub, mailing lists, etc.).
 * **Contributors:** Regular contributions to projects (documentation, code reviews, responding to issues, participation in proposal discussions, contributing code, etc.). 
+* **Subproject Reviewers and Maintainers:** Contributors with scoped responsibilities for a Harbor subproject, as defined in [SUBPROJECT_GOVERNANCE.md](SUBPROJECT_GOVERNANCE.md).
 * **Maintainers**: The Harbor project leaders. They are responsible for the overall health and direction of the project; final reviewers of PRs and responsible for releases. Some Maintainers are responsible for one or more components within a project, acting as technical leads for that component. Maintainers are expected to contribute code and documentation, review PRs including ensuring quality of code, triage issues, proactively fix bugs, and perform maintenance tasks for these components.
 
 ### Maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -48,20 +48,13 @@ Subproject maintainers and reviewers should be listed alphabetically by name.
 Recognized Harbor subproject maintainer groups should be mirrored in the CNCF
 `project-maintainers.csv` record using names such as `Harbor: <Subproject>`.
 
-### Harbor CLI
-
-Scope: Official Harbor CLI, [goharbor/harbor-cli](https://github.com/goharbor/harbor-cli)
-
-Status: active
-
-Maintainers:
-
-* Lakshit Singh ([NucleoFusion](https://github.com/NucleoFusion))
-* Patrick Eschenbach ([qcserestipy](https://github.com/qcserestipy))
-* Prasanth Baskar ([bupd](https://github.com/bupd))
-* Vadim Bauer ([Vad1mo](https://github.com/Vad1mo))
-
-Reviewers: -
+| Subproject | Scope | Status | Maintainers | Reviewers |
+| ---------- | ----- | ------ | ----------- | --------- |
+| Harbor CLI | Official Harbor CLI: [goharbor/harbor-cli](https://github.com/goharbor/harbor-cli) | active | - | - |
+|  |  |  | Lakshit Singh ([NucleoFusion](https://github.com/NucleoFusion)) |  |
+|  |  |  | Patrick Eschenbach ([qcserestipy](https://github.com/qcserestipy)) |  |
+|  |  |  | Prasanth Baskar ([bupd](https://github.com/bupd)) |  |
+|  |  |  | Vadim Bauer ([Vad1mo](https://github.com/Vad1mo)) |  |
 
 ## Harbor Core Contributors & Stakeholders
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -41,16 +41,27 @@ release, and contributor growth responsibilities for the listed subproject, but
 do not automatically become Harbor Maintainers.
 
 When a subproject has its own `MAINTAINERS.md`, that file is the source of truth
-for the scoped subproject roles and this table mirrors it.
+for the scoped subproject roles and this section mirrors it.
 
 Subproject maintainers and reviewers should be listed alphabetically by name.
 
 Recognized Harbor subproject maintainer groups should be mirrored in the CNCF
 `project-maintainers.csv` record using names such as `Harbor: <Subproject>`.
 
-| Subproject | Scope | Status | Maintainers | Reviewers |
-| ---------- | ----- | ------ | ----------- | --------- |
-| Harbor CLI | Official Harbor CLI: [goharbor/harbor-cli](https://github.com/goharbor/harbor-cli) | active | Lakshit Singh ([NucleoFusion](https://github.com/NucleoFusion)), Patrick Eschenbach ([qcserestipy](https://github.com/qcserestipy)), Prasanth Baskar ([bupd](https://github.com/bupd)), Vadim Bauer ([Vad1mo](https://github.com/Vad1mo)) | - |
+### Harbor CLI
+
+Scope: Official Harbor CLI, [goharbor/harbor-cli](https://github.com/goharbor/harbor-cli)
+
+Status: active
+
+Maintainers:
+
+* Lakshit Singh ([NucleoFusion](https://github.com/NucleoFusion))
+* Patrick Eschenbach ([qcserestipy](https://github.com/qcserestipy))
+* Prasanth Baskar ([bupd](https://github.com/bupd))
+* Vadim Bauer ([Vad1mo](https://github.com/Vad1mo))
+
+Reviewers: -
 
 ## Harbor Core Contributors & Stakeholders
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,8 @@
 
 [GOVERNANCE.md](https://github.com/goharbor/community/blob/master/GOVERNANCE.md)
 describes governance guidelines and maintainer responsibilities.
+[SUBPROJECT_GOVERNANCE.md](SUBPROJECT_GOVERNANCE.md) describes scoped
+subproject reviewers and maintainers.
 
 ## Maintainers
 
@@ -31,6 +33,24 @@ describes governance guidelines and maintainer responsibilities.
 | Owner | GitHub ID | Affiliation |
 | --------------- | --------- | ----------- |
 | ? | [?](https://github.com/?) | [?](https://www.github.com/?) |
+
+## Subprojects
+
+Subproject maintainers and reviewers are scoped roles. They own review, triage,
+release, and contributor growth responsibilities for the listed subproject, but
+do not automatically become Harbor Maintainers.
+
+When a subproject has its own `MAINTAINERS.md`, that file is the source of truth
+for the scoped subproject roles and this table mirrors it.
+
+Subproject maintainers and reviewers should be listed alphabetically by name.
+
+Recognized Harbor subproject maintainer groups should be mirrored in the CNCF
+`project-maintainers.csv` record using names such as `Harbor: <Subproject>`.
+
+| Subproject | Scope | Status | Maintainers | Reviewers |
+| ---------- | ----- | ------ | ----------- | --------- |
+| Harbor CLI | Official Harbor CLI: [goharbor/harbor-cli](https://github.com/goharbor/harbor-cli) | active | Lakshit Singh ([NucleoFusion](https://github.com/NucleoFusion)), Patrick Eschenbach ([qcserestipy](https://github.com/qcserestipy)), Prasanth Baskar ([bupd](https://github.com/bupd)), Vadim Bauer ([Vad1mo](https://github.com/Vad1mo)) | - |
 
 ## Harbor Core Contributors & Stakeholders
 
@@ -62,4 +82,3 @@ describes governance guidelines and maintainer responsibilities.
 * Alex Xu, [xaleeks](https://github.com/xaleeks)
 * Tianon Gravi, [tianon](https://github.com/tianon)
 * Daniel Pacak, [danielpacak](https://github.com/danielpacak)
-

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -50,8 +50,7 @@ Recognized Harbor subproject maintainer groups should be mirrored in the CNCF
 
 | Subproject | Scope | Status | Maintainers | Reviewers |
 | ---------- | ----- | ------ | ----------- | --------- |
-| Harbor CLI | Official Harbor CLI: [goharbor/harbor-cli](https://github.com/goharbor/harbor-cli) | active | - | - |
-|  |  |  | Lakshit Singh ([NucleoFusion](https://github.com/NucleoFusion)) |  |
+| Harbor CLI | Official Harbor CLI: [goharbor/harbor-cli](https://github.com/goharbor/harbor-cli) | active | Lakshit Singh ([NucleoFusion](https://github.com/NucleoFusion)) | - |
 |  |  |  | Patrick Eschenbach ([qcserestipy](https://github.com/qcserestipy)) |  |
 |  |  |  | Prasanth Baskar ([bupd](https://github.com/bupd)) |  |
 |  |  |  | Vadim Bauer ([Vad1mo](https://github.com/Vad1mo)) |  |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -54,6 +54,7 @@ Recognized Harbor subproject maintainer groups should be mirrored in the CNCF
 |  |  |  | Patrick Eschenbach ([qcserestipy](https://github.com/qcserestipy)) |  |
 |  |  |  | Prasanth Baskar ([bupd](https://github.com/bupd)) |  |
 |  |  |  | Vadim Bauer ([Vad1mo](https://github.com/Vad1mo)) |  |
+| Terraform/Opentofu Provider | Official Terraform/Opentofu provider : [goharbor/terraform-provider-harbor](https://github.com/goharbor/terraform-provider-harbor) | active | Florian Blampey ([flbla](https://github.com/flbla)) | - |
 
 ## Harbor Core Contributors & Stakeholders
 

--- a/SUBPROJECT_GOVERNANCE.md
+++ b/SUBPROJECT_GOVERNANCE.md
@@ -1,0 +1,119 @@
+# Harbor Subproject Governance
+
+This document defines lightweight governance for Harbor subprojects, reviewers,
+and subproject maintainers. Harbor keeps this model intentionally small.
+
+## Roles
+
+### Contributor
+
+A contributor helps Harbor through code, documentation, testing, issue triage,
+release work, packaging, community support, design review, or mentoring.
+
+### Subproject Reviewer
+
+A subproject reviewer is trusted to review and triage changes in a defined
+subproject. Reviewers help contributors get work ready, but do not own the
+subproject direction. Reviewers are listed in `MAINTAINERS.md`.
+
+### Subproject Maintainer
+
+A subproject maintainer owns the health of a defined Harbor subproject.
+
+Responsibilities:
+
+* Review, approve, and help merge changes in the subproject.
+* Triage issues and pull requests.
+* Keep documentation, tests, release notes, and ownership metadata current.
+* Mentor contributors and reviewers.
+* Coordinate releases or packaging when the subproject publishes artifacts.
+* Escalate cross-project, security, or disputed decisions to Harbor Maintainers.
+
+Subproject maintainership is scoped. It does not automatically grant Harbor
+Maintainer status or project-wide decision authority.
+
+### Harbor Maintainer
+
+Harbor Maintainers are the project-wide maintainers defined in `GOVERNANCE.md`.
+They are listed in `MAINTAINERS.md` and the CNCF `project-maintainers.csv`
+record for Harbor. New Harbor Maintainers must still be nominated and elected
+through the existing Harbor maintainer process.
+
+## Subprojects
+
+A Harbor subproject is a long-lived area of responsibility under the Harbor
+community. It may own a repository, multiple repositories, or a clear area
+inside a repository.
+
+Active subprojects may maintain their own `MAINTAINERS.md`. That file is the
+source of truth for the subproject's scoped maintainers and reviewers, and the
+Harbor community `MAINTAINERS.md` should mirror it.
+
+Each subproject entry in `MAINTAINERS.md` should include:
+
+* Name and scope.
+* Owned repositories or paths.
+* Subproject maintainers.
+* Subproject reviewers, if any.
+* Status: `active`, `maintenance`, or `archived`.
+
+Subproject maintainers and reviewers should be listed alphabetically by name.
+
+Workgroups remain useful for temporary or cross-cutting initiatives. A
+workgroup does not automatically own code, releases, or maintainer permissions.
+
+## Role Changes
+
+Reviewer:
+
+* May be nominated by any contributor, including self-nomination.
+* Requires approval from at least one subproject maintainer.
+* If the subproject has no maintainer, approval comes from a Harbor Maintainer.
+
+Subproject maintainer:
+
+* May be nominated by a subproject maintainer or Harbor Maintainer.
+* If the subproject has no active maintainer, a Harbor Maintainer may nominate.
+* Active subprojects choose their own maintainers within their documented
+  subproject process.
+* The nominee must confirm willingness to take the role.
+* Approval requires consensus from active subproject maintainers, or Harbor
+  Maintainer approval when bootstrapping or resolving a deadlock.
+
+Harbor Maintainer:
+
+* Uses the existing process in `GOVERNANCE.md`: nomination by an existing Harbor
+  Maintainer and supermajority election by existing Harbor Maintainers.
+
+## Inactivity
+
+Anyone may step down from a reviewer, subproject maintainer, or Harbor
+Maintainer role.
+
+Inactive reviewers and subproject maintainers may be moved to emeritus status
+by PR after reasonable contact attempts. The purpose is to keep ownership
+accurate and make room for active contributors.
+
+Harbor Maintainer removal remains governed by `GOVERNANCE.md`.
+
+## Records
+
+`MAINTAINERS.md` is Harbor's source of truth for Harbor Maintainers,
+subproject maintainers, reviewers, and emeritus roles.
+
+The CNCF `project-maintainers.csv` record should include Harbor Maintainers and
+recognized Harbor subproject maintainer groups, using names such as
+`Harbor: <Subproject>`.
+
+Repository permissions, CODEOWNERS, and release access should match the roles
+documented in `MAINTAINERS.md`.
+
+## References
+
+This model takes inspiration from:
+
+* Kubernetes governance: https://github.com/kubernetes/community/blob/main/governance.md
+* Kubernetes community membership: https://github.com/kubernetes/community/blob/main/community-membership.md
+* CNCF subproject governance template: https://github.com/cncf/project-template/blob/main/GOVERNANCE-subprojects.md
+* OpenTelemetry membership roles: https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md
+* Prometheus governance: https://prometheus.io/governance/

--- a/SUBPROJECT_GOVERNANCE.md
+++ b/SUBPROJECT_GOVERNANCE.md
@@ -1,7 +1,7 @@
 # Harbor Subproject Governance
 
-This document defines lightweight governance for Harbor subprojects, reviewers,
-and subproject maintainers. Harbor keeps this model intentionally small.
+This document defines governance for Harbor subprojects, reviewers,
+and subproject maintainers.
 
 ## Roles
 
@@ -32,13 +32,6 @@ Responsibilities:
 Subproject maintainership is scoped. It does not automatically grant Harbor
 Maintainer status or project-wide decision authority.
 
-### Harbor Maintainer
-
-Harbor Maintainers are the project-wide maintainers defined in `GOVERNANCE.md`.
-They are listed in `MAINTAINERS.md` and the CNCF `project-maintainers.csv`
-record for Harbor. New Harbor Maintainers must still be nominated and elected
-through the existing Harbor maintainer process.
-
 ## Subprojects
 
 A Harbor subproject is a long-lived area of responsibility under the Harbor
@@ -59,9 +52,6 @@ Each subproject entry in `MAINTAINERS.md` should include:
 
 Subproject maintainers and reviewers should be listed alphabetically by name.
 
-Workgroups remain useful for temporary or cross-cutting initiatives. A
-workgroup does not automatically own code, releases, or maintainer permissions.
-
 ## Role Changes
 
 Reviewer:
@@ -80,21 +70,13 @@ Subproject maintainer:
 * Approval requires consensus from active subproject maintainers, or Harbor
   Maintainer approval when bootstrapping or resolving a deadlock.
 
-Harbor Maintainer:
-
-* Uses the existing process in `GOVERNANCE.md`: nomination by an existing Harbor
-  Maintainer and supermajority election by existing Harbor Maintainers.
-
 ## Inactivity
 
-Anyone may step down from a reviewer, subproject maintainer, or Harbor
-Maintainer role.
+Anyone may step down from a reviewer or subproject maintainer role.
 
 Inactive reviewers and subproject maintainers may be moved to emeritus status
 by PR after reasonable contact attempts. The purpose is to keep ownership
 accurate and make room for active contributors.
-
-Harbor Maintainer removal remains governed by `GOVERNANCE.md`.
 
 ## Records
 


### PR DESCRIPTION
Adds lightweight Harbor subproject governance and records Harbor CLI as an active Harbor subproject.

## Why

Harbor has subprojects with their own maintainers, but the community repo does not currently document scoped subproject reviewer/maintainer roles under the Harbor project. This makes subproject ownership visible without changing the existing Harbor Maintainer election process.

## Prior art

This follows common governance patterns used by CNCF projects:

- Kubernetes documents SIGs, subprojects, reviewers, approvers, and subproject owners:
  - https://github.com/kubernetes/community/blob/main/governance.md
  - https://github.com/kubernetes/community/blob/main/community-membership.md
- CNCF's project template includes dedicated subproject governance guidance:
  - https://github.com/cncf/project-template/blob/main/GOVERNANCE-subprojects.md
- OpenTelemetry defines maintainers as scoped technical authorities for subprojects:
  - https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md
- Prometheus ties maintainership to individual projects or parts of projects:
  - https://prometheus.io/governance/
- Backstage uses project areas with scoped maintainers and self-governing ownership areas:
  - https://github.com/backstage/community/blob/main/GOVERNANCE.md
- containerd distinguishes core and non-core subprojects, with subproject-specific maintainer lists and scoped responsibility:
  - https://github.com/containerd/project/blob/main/GOVERNANCE.md
- Envoy records scoped maintainers/code owners for areas such as Envoy Mobile and extensions:
  - https://github.com/envoyproxy/envoy/blob/main/OWNERS.md

This keeps the Harbor version intentionally small: scoped subproject reviewers/maintainers, subproject autonomy, `MAINTAINERS.md` as the community record, and no change to top-level Harbor Maintainer governance.
