### PR TITLE
Revert "Nominate Prasanth Baskar as maintainer"

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,6 @@ describes governance guidelines and maintainer responsibilities.
 | Jérémie MONSINJON | [Jérémie MONSINJON](https://github.com/jMonsinjon) | [OVH Cloud](https://www.ovh.com/world/) | 
 | Pierre PÉRONNET | [holyhope](https://github.com/holyhope) | [DataDog](https://www.datadoghq.com) |
 | Vadim Bauer | [Vad1mo](https://github.com/Vad1mo) | [8gears](https://container-registry.com) |
-| Prasanth Baskar | [bupd](https://github.com/bupd) | [8gears](https://container-registry.com) |
 
 ## SIG Community
 


### PR DESCRIPTION
Reverts goharbor/community#289

Reverting this PR as it was merged accidentally(Per the discussion offline). We need to adhere to our official nomination process to secure a majority approval from the maintainer group:

📖 [Harbor Community Governance - Maintainers](https://github.com/goharbor/community/blob/main/GOVERNANCE.md#maintainers)

Let's continue the discussion and review on the original nomination pull request:
🔗 https://github.com/goharbor/community/pull/264

Maintainers, you guys should give your comments and feedback for this nomination.

@bupd, could you please add your list of contributions to that thread? Thank you!


